### PR TITLE
Initialize Discord.Net Bot with Secrets Management and Ping Pong Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Secrets management
+Secrets/

--- a/Data/DatabaseService.cs
+++ b/Data/DatabaseService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Data.SQLite;
+using System.IO;
+using System.Threading.Tasks;
+using Dapper;
+
+namespace Mundo.Data
+{
+    public class DatabaseService
+    {
+        private readonly string _dbPath;
+
+        public DatabaseService()
+        {
+            string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            string dataDir = Path.Combine(baseDir, "Data");
+            if (!Directory.Exists(dataDir))
+                Directory.CreateDirectory(dataDir);
+            _dbPath = Path.Combine(dataDir, "mundo.sqlite");
+            EnsureDatabase().Wait();
+        }
+
+        private async Task EnsureDatabase()
+        {
+            bool newDb = !File.Exists(_dbPath);
+            using (var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;"))
+            {
+                await connection.OpenAsync();
+                if (newDb)
+                {
+                    // Will be created automatically by SQLiteConnection
+                }
+                await connection.ExecuteAsync(
+                    @"CREATE TABLE IF NOT EXISTS PingLogs (
+                        Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        UserId TEXT NOT NULL,
+                        Timestamp INTEGER NOT NULL
+                    );");
+            }
+        }
+
+        public async Task LogPing(ulong userId)
+        {
+            using (var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;"))
+            {
+                await connection.OpenAsync();
+                var sql = "INSERT INTO PingLogs (UserId, Timestamp) VALUES (@UserId, @Timestamp);";
+                await connection.ExecuteAsync(sql, new
+                {
+                    UserId = userId.ToString(),
+                    Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                });
+            }
+        }
+    }
+}

--- a/Mundo.csproj
+++ b/Mundo.csproj
@@ -102,10 +102,18 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+    <Reference Include="System.Data.SQLite">
+      <HintPath>packages\System.Data.SQLite.Core.1.0.119.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="Dapper">
+      <HintPath>packages\Dapper.2.0.123\lib\net46\Dapper.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Secrets\Secrets.cs" />
+    <Compile Include="Data\DatabaseService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,15 +1,75 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
 using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Mundo.Secrets;
+using Mundo.Data;
 
 namespace Mundo
 {
-    internal class Program
+    class Program
     {
+        private DiscordSocketClient _client;
+        private DatabaseService _db;
+
         static void Main(string[] args)
         {
+            new Program().MainAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task MainAsync()
+        {
+            // Load secrets
+            var secrets = Secrets.Secrets.Load();
+            if (string.IsNullOrWhiteSpace(secrets.BotToken) || secrets.BotToken == "YOUR_DISCORD_BOT_TOKEN_HERE")
+            {
+                Console.WriteLine("Bot token missing in Secrets/secrets.json. Please set your Discord bot token.");
+                return;
+            }
+
+            // Init DB
+            _db = new DatabaseService();
+
+            // Discord client
+            var config = new DiscordSocketConfig
+            {
+                GatewayIntents = GatewayIntents.AllUnprivileged
+            };
+            _client = new DiscordSocketClient(config);
+
+            _client.Log += LogAsync;
+            _client.Ready += OnReadyAsync;
+            _client.MessageReceived += HandleMessageReceivedAsync;
+
+            await _client.LoginAsync(TokenType.Bot, secrets.BotToken);
+            await _client.StartAsync();
+
+            await Task.Delay(-1);
+        }
+
+        private Task LogAsync(LogMessage msg)
+        {
+            Console.WriteLine(msg.ToString());
+            return Task.CompletedTask;
+        }
+
+        private Task OnReadyAsync()
+        {
+            Console.WriteLine($"Bot is connected as {_client.CurrentUser}");
+            return Task.CompletedTask;
+        }
+
+        private async Task HandleMessageReceivedAsync(SocketMessage message)
+        {
+            // Ignore self, bots, and system messages
+            if (!(message is SocketUserMessage userMsg)) return;
+            if (userMsg.Author.IsBot) return;
+
+            if (userMsg.Content.Trim().Equals("!ping", StringComparison.OrdinalIgnoreCase))
+            {
+                await message.Channel.SendMessageAsync("Pong!");
+                await _db.LogPing(userMsg.Author.Id);
+            }
         }
     }
 }

--- a/Secrets/Secrets.cs
+++ b/Secrets/Secrets.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Mundo.Secrets
+{
+    public class SecretsModel
+    {
+        public string BotToken { get; set; }
+    }
+
+    public static class Secrets
+    {
+        public static SecretsModel Load()
+        {
+            string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            string secretsPath = Path.Combine(baseDir, "Secrets", "secrets.json");
+            if (!File.Exists(secretsPath))
+                throw new FileNotFoundException($"Secrets file not found: {secretsPath}");
+            string json = File.ReadAllText(secretsPath);
+            return JsonConvert.DeserializeObject<SecretsModel>(json);
+        }
+    }
+}

--- a/Secrets/secrets.json
+++ b/Secrets/secrets.json
@@ -1,0 +1,3 @@
+{
+  "BotToken": "YOUR_DISCORD_BOT_TOKEN_HERE"
+}

--- a/packages.config
+++ b/packages.config
@@ -1,8 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Discord.Net" version="3.14.1" targetFramework="net472" />
-  <package id="System.Data.SQLite.Core" version="1.0.119.0" targetFramework="net472" />
-  <package id="Dapper" version="2.0.123" targetFramework="net472" />
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Discord.Net" version="3.17.4" targetFramework="net472" />
   <package id="Discord.Net.Commands" version="3.17.4" targetFramework="net472" />
@@ -24,4 +20,6 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+  <package id="System.Data.SQLite.Core" version="1.0.119.0" targetFramework="net472" />
+  <package id="Dapper" version="2.0.123" targetFramework="net472" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Discord.Net" version="3.14.1" targetFramework="net472" />
+  <package id="System.Data.SQLite.Core" version="1.0.119.0" targetFramework="net472" />
+  <package id="Dapper" version="2.0.123" targetFramework="net472" />
+<packages>
   <package id="Discord.Net" version="3.17.4" targetFramework="net472" />
   <package id="Discord.Net.Commands" version="3.17.4" targetFramework="net472" />
   <package id="Discord.Net.Core" version="3.17.4" targetFramework="net472" />


### PR DESCRIPTION
This pull request implements the initial setup for a Discord.Net bot, incorporating secrets management and a relational database. 

### Changes Made:
1. **Secrets Management**: A new folder `Secrets/` has been added, along with a `Secrets.cs` file for loading the bot token securely. A sample `secrets.json` has also been created to provide users with a template.
2. **Database Integration**: Introduced a `DatabaseService` class to handle SQLite database interactions, including a `PingLogs` table and a method to log pings from users.
3. **Ping Pong Logic**: Modified the `Program.cs` to respond to the `!ping` command with `Pong!`, logging each user's ping into the database.
4. **Dependency Updates**: Updated the project files to include necessary packages for Dapper and SQLite.

### How to Use:
1. Place your Discord bot token in `Secrets/secrets.json` replacing `YOUR_DISCORD_BOT_TOKEN_HERE`.
2. Run the bot and use the `!ping` command in any Discord channel to test the functionality.
3. The bot will log each ping to the SQLite database.

---

> This pull request was co-created with Cosine Genie

Original Task: [MundoD/7v4gf104qsmo](https://cosine.sh/uyj0k4lc37n5/MundoD/task/7v4gf104qsmo)
Author: Gote Mazzy
